### PR TITLE
fix: remove db initialization from firebase

### DIFF
--- a/src/components/shared/Firebase/firebase.js
+++ b/src/components/shared/Firebase/firebase.js
@@ -19,7 +19,8 @@ class Firebase {
     app.initializeApp(config);
 
     this.auth = app.auth();
-    this.db = app.database();
+    // Db is not in use but available if needed
+    // this.db = app.database();
     this.firestore = app.firestore();
 
     /* Helper */


### PR DESCRIPTION
This change fixes errors with loading the app for the first time

## Changes

For some reason firebase doesn't;t like instances initialized without using them. In this case, we are initializing DB but not using it

## Screenshots

(prefer animated gif)

## Checklist

- [ ] Requires dependency update?
- [ ] Automated tests
- [ ] Looks good on large screens
- [ ] Looks good on mobile
- [ ] Ping @mo-sharif for visibility
